### PR TITLE
update custom log types example

### DIFF
--- a/helpers/custom_log_types.py
+++ b/helpers/custom_log_types.py
@@ -1,3 +1,5 @@
+# Custom log schemas must be present in your Panther instance for upload to work
+# The log type names defined here do not need to include the "Custom." prefix that is automatically added in the Panther UI
 class CustomLogType:
-    HOST_IDS = "Custom.HostIDS"
-    NETWORK_IDS = "Custom.NetworkIDS"
+    HOST_IDS = "HostIDS"
+    NETWORK_IDS = "NetworkIDS"


### PR DESCRIPTION
Rohan and I did some testing and figured out that the v2 upload calls the logtypesapi to determine the AllowedLogTypes.  So the custom schema has to be present in the Panther instance you are uploading to.  The trick is that it ignores the `Custom.` that is automatically added to custom schema names.  If the schema is `Custom.HostIDS` in the Panther UI, it should be `HostIDS` in your `CustomLogType` enum.