### PR TITLE
deregistering custom log types

### DIFF
--- a/helpers/custom_log_types.py
+++ b/helpers/custom_log_types.py
@@ -1,3 +1,6 @@
-class CustomLogType:
+from enum import Enum
+
+
+class CustomLogType(Enum):
     HOST_IDS = "Custom.HostIDS"
     NETWORK_IDS = "Custom.NetworkIDS"

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 from pypanther import get_panther_rules, get_rules, register
 
+from helpers.custom_log_types import CustomLogType
+from overrides import aws_cloudtrail, aws_guardduty
 from rules import examples
 
 # from overrides import aws_cloudtrail, aws_guardduty
@@ -17,12 +19,13 @@ base_rules = get_panther_rules(
     # ],
 )
 # Load all local custom rules
-# TODO: Update when custom rules are functional
 custom_rules = get_rules(module=examples)
+# Omit rules with custom log types, since they must be present in the Panther instance for upload to work
+custom_rules = [rule for rule in custom_rules if not any(custom in rule.log_types for custom in CustomLogType)]
 
 # Apply overrides
-# aws_cloudtrail.apply_overrides(base_rules)
-# aws_guardduty.apply_overrides(base_rules)
+aws_cloudtrail.apply_overrides(base_rules)
+aws_guardduty.apply_overrides(base_rules)
 
 # Register all rules
 register(base_rules + custom_rules)

--- a/main.py
+++ b/main.py
@@ -4,8 +4,6 @@ from helpers.custom_log_types import CustomLogType
 from overrides import aws_cloudtrail, aws_guardduty
 from rules import examples
 
-# from overrides import aws_cloudtrail, aws_guardduty
-
 # Load base rules
 base_rules = get_panther_rules(
     # log_types=[


### PR DESCRIPTION
Since custom log types must be present in the Panther instance for upload to work, don't register them.  Allowing starter kit to upload out-of-the-box.