### PR TITLE
update filters for 0.1.1a47

### DIFF
--- a/helpers/cloud.py
+++ b/helpers/cloud.py
@@ -22,21 +22,6 @@ def account_lookup_by_id(account_id):
     return "Account ID not found in lookup. Please update helpers.CLOUD_ACCOUNTS"
 
 
-def update_account_id_tests(rules):
-    sample_account_id = (
-        list(prod_account_ids)[0]
-        if prod_account_ids
-        else list(dev_accounts_ids)[0]
-        if dev_accounts_ids
-        else list(test_accounts_ids)[0]
-        if test_accounts_ids
-        else "123456789012"
-    )
-    for rule in rules:
-        for test in rule.tests:
-            test.log["recipientAccountId"] = sample_account_id
-
-
 # Pre-calculates a set of IDs to be used in overrides and filters
 prod_account_ids = {account["accountID"] for account in CLOUD_ACCOUNTS["Production"]}
 dev_accounts_ids = {account["accountID"] for account in CLOUD_ACCOUNTS["Development"]}

--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
-from pypanther import get_panther_rules, get_rules, register
-
 from helpers.custom_log_types import CustomLogType
 from overrides import aws_cloudtrail, aws_guardduty
 from rules import examples
+
+from pypanther import get_panther_rules, get_rules, register
 
 # Load base rules
 base_rules = get_panther_rules(

--- a/overrides/aws_cloudtrail.py
+++ b/overrides/aws_cloudtrail.py
@@ -1,17 +1,19 @@
-from pypanther import Severity
-from pypanther.rules.aws_cloudtrail_rules.aws_cloudtrail_stopped import AWSCloudTrailStopped
-from pypanther.rules.aws_cloudtrail_rules.aws_console_root_login import AWSConsoleRootLogin
-from pypanther.wrap import include
-
 from helpers.cloud import account_lookup_by_id, prod_account_ids, update_account_id_tests
+
+from pypanther import Severity
+from pypanther.rules.aws_cloudtrail.aws_cloudtrail_stopped import AWSCloudTrailStopped
+from pypanther.rules.aws_cloudtrail.aws_console_root_login import AWSConsoleRootLogin
 
 
 def root_login_account_title(_, event):
     """
     Generates a dynamic alert title for root logins using account mappings.
+
     Args:
+    ----
         _ (self): The PantherRule instance (unused)
         event (dict): The CloudTrail event
+
     """
     ip_address = event.get("sourceIPAddress")
     account = account_lookup_by_id(event.get("recipientAccountId"))
@@ -39,7 +41,7 @@ def apply_overrides(rules):
     )
 
     # Add an include filter with the prod_account_filter function
-    include(prod_account_filter)(AWSCloudTrailStopped)
+    AWSCloudTrailStopped.extend(include_filters=[prod_account_filter])
     update_account_id_tests([AWSCloudTrailStopped])
 
     # Override a rule's title function

--- a/overrides/aws_cloudtrail.py
+++ b/overrides/aws_cloudtrail.py
@@ -1,4 +1,4 @@
-from helpers.cloud import account_lookup_by_id, prod_account_ids, update_account_id_tests
+from helpers.cloud import account_lookup_by_id, prod_account_ids
 
 from pypanther import Severity
 from pypanther.rules.aws_cloudtrail.aws_cloudtrail_stopped import AWSCloudTrailStopped
@@ -42,7 +42,6 @@ def apply_overrides(rules):
 
     # Add an include filter with the prod_account_filter function
     AWSCloudTrailStopped.extend(include_filters=[prod_account_filter])
-    update_account_id_tests([AWSCloudTrailStopped])
 
     # Override a rule's title function
     AWSConsoleRootLogin.title = root_login_account_title

--- a/overrides/aws_guardduty.py
+++ b/overrides/aws_guardduty.py
@@ -1,6 +1,5 @@
 from pypanther import LogType, RuleTest
-from pypanther.rules.aws_guardduty_rules.aws_guardduty_high_sev_findings import AWSGuardDutyHighSeverityFinding
-from pypanther.wrap import exclude, include
+from pypanther.rules.aws_guardduty.aws_guardduty_high_sev_findings import AWSGuardDutyHighSeverityFinding
 
 sensitive_aws_services = {"s3", "dynamodb", "iam", "secretsmanager", "ec2"}
 
@@ -31,6 +30,8 @@ guard_duty_high_sev_test = RuleTest(
 def apply_overrides(rules):
     for rule in rules:
         if LogType.AWS_GUARDDUTY in rule.log_types:
-            exclude(guard_duty_discovery_filter)(rule)
-            include(guard_duty_sensitive_service_filter)(rule)
+            rule.extend(
+                exclude_filters=[guard_duty_discovery_filter],
+                include_filters=[guard_duty_sensitive_service_filter],
+            )
     AWSGuardDutyHighSeverityFinding.tests.append(guard_duty_high_sev_test)

--- a/poetry.lock
+++ b/poetry.lock
@@ -195,17 +195,17 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.35.8"
+version = "1.35.10"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.35.8-py3-none-any.whl", hash = "sha256:06eac4757de2a9c6020381205cb902f05964caad80b56e58c8931284a133b4cb"},
-    {file = "boto3-1.35.8.tar.gz", hash = "sha256:b9587131372a808bf6f99c5ed8b11be55cd113261cc3b437a917b4acc6c30bfe"},
+    {file = "boto3-1.35.10-py3-none-any.whl", hash = "sha256:add26dd58e076dfd387013da4704716d5cff215cf14f6d4347c4b9b7fc1f0b8e"},
+    {file = "boto3-1.35.10.tar.gz", hash = "sha256:189ab1e2b4cd86df56f82438d89b4040eb140c92683f1bda7cb2e62624f20ea5"},
 ]
 
 [package.dependencies]
-botocore = ">=1.35.8,<1.36.0"
+botocore = ">=1.35.10,<1.36.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -214,13 +214,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.35.8"
+version = "1.35.10"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.35.8-py3-none-any.whl", hash = "sha256:adf389eb8fd87775f193300e3431d1353f925807ad3a39958172cb644f0d60a1"},
-    {file = "botocore-1.35.8.tar.gz", hash = "sha256:4b820cf680ab5d778bd2fe4feeef1ff8a2b96d5c535d4638ab30f703ade282f8"},
+    {file = "botocore-1.35.10-py3-none-any.whl", hash = "sha256:0d96d023b9b0cea99a0a428a431d011329d3a958730aee6ed6a6fec5d9bfbc03"},
+    {file = "botocore-1.35.10.tar.gz", hash = "sha256:6c8a1377b6636a0d80218115e1cd41bcceba0a2f050b79c206f4cf8d002c54d7"},
 ]
 
 [package.dependencies]
@@ -233,13 +233,13 @@ crt = ["awscrt (==0.21.2)"]
 
 [[package]]
 name = "certifi"
-version = "2024.7.4"
+version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
-    {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
+    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
+    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
 ]
 
 [[package]]
@@ -896,13 +896,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pypanther"
-version = "0.1.1a46"
+version = "0.1.1a47"
 description = ""
 optional = false
 python-versions = "==3.11.*"
 files = [
-    {file = "pypanther-0.1.1a46-py3-none-any.whl", hash = "sha256:e70f46cd5599d5c8d0fa7bb09a49e9ceb4050ef6ac272683dd54902c6a3f33cf"},
-    {file = "pypanther-0.1.1a46.tar.gz", hash = "sha256:a105515e7c82a34664b94a269d3cb1b9beea5c0e40b20ee99a452575a801e778"},
+    {file = "pypanther-0.1.1a47-py3-none-any.whl", hash = "sha256:bac8113d79aed9e89e9f2d41d553d55200d33197f26e2ada0f08bdfe3ed9c632"},
+    {file = "pypanther-0.1.1a47.tar.gz", hash = "sha256:05dd391edc430f96d3357231ac98f66844ae282d3e18a0594ed9880354a1a154"},
 ]
 
 [package.dependencies]
@@ -1242,4 +1242,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.*"
-content-hash = "64d8f8de5ff35302c2ca9fc562313c4fda74cb92552abbd9332608b685a4ffa3"
+content-hash = "911ee14a10c9a899f6607300b63e5084f1fa996d4caa062d441818a95725a50a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "3.11.*"
-pypanther = "^0.1.1a45"
+pypanther = "^0.1.1a47"
 panther-core = "^0.11.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/rules/examples/inheritance_rules.py
+++ b/rules/examples/inheritance_rules.py
@@ -1,7 +1,6 @@
-from pypanther import Rule, RuleTest, Severity
-from pypanther.wrap import include
-
 from helpers.custom_log_types import CustomLogType
+
+from pypanther import Rule, RuleTest, Severity
 
 
 # Base rule for a custom log type.
@@ -25,7 +24,7 @@ class HostIDSBaseRule(Rule):
                 "event_time": "2021-01-01T00:00:00Z",
                 "user_agent": "Chrome",
             },
-        )
+        ),
     ]
 
     _compromise_type = "compromise"
@@ -52,11 +51,11 @@ class HostIDSBaseRule(Rule):
 
 
 # Inherited rule #1
-@include(lambda e: e.get("event_type") == "c2")
 class HostIDSCommandAndControl(HostIDSBaseRule):
     id = "HostIDS.CommandAndControl"
     enabled = True
     threshold = 18
+    include_filters = [lambda e: e.get("event_type") == "c2"]
     _compromise_type = "command and control"
 
     tests = [
@@ -70,7 +69,7 @@ class HostIDSCommandAndControl(HostIDSBaseRule):
                 "event_time": "2021-01-01T00:00:00Z",
                 "user_agent": "Chrome",
             },
-        )
+        ),
     ]
 
 
@@ -94,7 +93,7 @@ class HostIDSMalware(HostIDSBaseRule):
                 "event_time": "2021-01-01T00:00:00Z",
                 "user_agent": "Chrome",
             },
-        )
+        ),
     ]
 
     def rule(self, event):


### PR DESCRIPTION
Updates pypanther to 0.1.1a47.

Uses new `extend` function, `include_filters`, and `exclude_filters`. 