### PR TITLE
Example of new mock functionality

### DIFF
--- a/content/rules/example_mocks.py
+++ b/content/rules/example_mocks.py
@@ -49,7 +49,7 @@ class MockTestRule(Rule):
                 RuleMock(
                     # Mock the method inside() with a side effect that checks if the action is "Blocked"
                     object_name="inside",
-                    side_effect=lambda e: bool(e.get("action") == "Blocked"),
+                    side_effect=lambda e: e.get("action") == "Blocked",
                 )
             ],
             log={"action": "Blocked", "internalIp": ""},

--- a/content/rules/example_mocks.py
+++ b/content/rules/example_mocks.py
@@ -1,5 +1,4 @@
-from pypanther import RuleTest, Rule, RuleMock, LogType, Severity
-
+from pypanther import LogType, Rule, RuleMock, RuleTest, Severity
 
 # This is an example of how to use mocks in your tests.
 # The mocks are used to replace the actual object with a mock object.
@@ -8,8 +7,11 @@ from pypanther import RuleTest, Rule, RuleMock, LogType, Severity
 # http://www.ines-panker.com/2020/06/01/python-mock.html
 
 OUTSIDE = "outside"
+
+
 def outside():
     return OUTSIDE
+
 
 class MockTestRule(Rule):
     id = "mock_test_rule"
@@ -19,11 +21,11 @@ class MockTestRule(Rule):
     default_severity = Severity.INFO
     create_alert = False
 
-    VARIABLE = []
+    VARIABLE: list[str] = []
 
     def rule(self, event):
         return self.VARIABLE != []
-    
+
     tests = [
         RuleTest(
             name="Mock new Test",
@@ -32,13 +34,10 @@ class MockTestRule(Rule):
                 RuleMock(
                     # Mock the object VARIABLE with a new object ["test"]
                     object_name="VARIABLE",
-                    new=["test"]
+                    new=["test"],
                 )
             ],
-            log={
-                "action": "Blocked",
-                "internalIp": ""
-            }
+            log={"action": "Blocked", "internalIp": ""},
         ),
         RuleTest(
             name="Mock side_effect Test",
@@ -47,13 +46,10 @@ class MockTestRule(Rule):
                 RuleMock(
                     # Mock the method rule() with a side effect that checks if the action is "Blocked"
                     object_name="rule",
-                    side_effect=lambda e: e.get("action") == "Blocked"
+                    side_effect=lambda e: e.get("action") == "Blocked",
                 )
             ],
-            log={
-                "action": "Blocked",
-                "internalIp": ""
-            }
+            log={"action": "Blocked", "internalIp": ""},
         ),
         RuleTest(
             name="Mock return_value Test",
@@ -62,29 +58,27 @@ class MockTestRule(Rule):
                 RuleMock(
                     # Mock the method rule() with a return value of True
                     object_name="rule",
-                    return_value=True
+                    return_value=True,
                 )
             ],
-            log={
-                "action": "Blocked",
-                "internalIp": ""
-            }
+            log={"action": "Blocked", "internalIp": ""},
         ),
     ]
 
 
-    
 class OutsideMockTest(Rule):
     id = "outside_mock_test"
     display_name = "Outside Mock Test"
-    default_description = "This rule provides an example of how to mock objects outside of the rule class in rule tests."
+    default_description = (
+        "This rule provides an example of how to mock objects outside of the rule class in rule tests."
+    )
     log_types = [LogType.AZURE_AUDIT]
     default_severity = Severity.INFO
     create_alert = False
 
     def rule(self, event):
         return outside() == "outside"
-    
+
     tests = [
         RuleTest(
             name="Mock outside new",
@@ -93,13 +87,10 @@ class OutsideMockTest(Rule):
                 RuleMock(
                     # Mock the object OUTSIDE with a new value "inside"
                     object_name="OUTSIDE",
-                    new="inside"
+                    new="inside",
                 )
             ],
-            log={
-                "action": "Blocked",
-                "internalIp": ""
-            }
+            log={"action": "Blocked", "internalIp": ""},
         ),
         RuleTest(
             name="Mock outside return_value",
@@ -108,13 +99,10 @@ class OutsideMockTest(Rule):
                 RuleMock(
                     # Mock the function outside() with a return value "inside"
                     object_name="outside",
-                    return_value="inside"
+                    return_value="inside",
                 )
             ],
-            log={
-                "action": "Blocked",
-                "internalIp": ""
-            }
+            log={"action": "Blocked", "internalIp": ""},
         ),
         RuleTest(
             name="Mock outside side_effect",
@@ -123,12 +111,9 @@ class OutsideMockTest(Rule):
                 RuleMock(
                     # Mock the function outside() with a side effect that returns "inside"
                     object_name="outside",
-                    side_effect=lambda: "inside"
+                    side_effect=lambda: "inside",
                 )
             ],
-            log={
-                "action": "Blocked",
-                "internalIp": ""
-            }
+            log={"action": "Blocked", "internalIp": ""},
         ),
     ]

--- a/content/rules/example_mocks.py
+++ b/content/rules/example_mocks.py
@@ -1,0 +1,134 @@
+from pypanther import RuleTest, Rule, RuleMock, LogType, Severity
+
+
+# This is an example of how to use mocks in your tests.
+# The mocks are used to replace the actual object with a mock object.
+# The mock object can be a new object, a return value, or a side effect.
+# You can mock objects that are defined in the rule class or outside of the rule class.
+# http://www.ines-panker.com/2020/06/01/python-mock.html
+
+OUTSIDE = "outside"
+def outside():
+    return OUTSIDE
+
+class MockTestRule(Rule):
+    id = "mock_test_rule"
+    display_name = "Mock Test Rule"
+    default_description = "This rule provides an example of how to mock objects within a rule in rule tests."
+    log_types = [LogType.AZURE_AUDIT]
+    default_severity = Severity.INFO
+    create_alert = False
+
+    VARIABLE = []
+
+    def rule(self, event):
+        return self.VARIABLE != []
+    
+    tests = [
+        RuleTest(
+            name="Mock new Test",
+            expected_result=True,
+            mocks=[
+                RuleMock(
+                    # Mock the object VARIABLE with a new object ["test"]
+                    object_name="VARIABLE",
+                    new=["test"]
+                )
+            ],
+            log={
+                "action": "Blocked",
+                "internalIp": ""
+            }
+        ),
+        RuleTest(
+            name="Mock side_effect Test",
+            expected_result=True,
+            mocks=[
+                RuleMock(
+                    # Mock the method rule() with a side effect that checks if the action is "Blocked"
+                    object_name="rule",
+                    side_effect=lambda e: e.get("action") == "Blocked"
+                )
+            ],
+            log={
+                "action": "Blocked",
+                "internalIp": ""
+            }
+        ),
+        RuleTest(
+            name="Mock return_value Test",
+            expected_result=True,
+            mocks=[
+                RuleMock(
+                    # Mock the method rule() with a return value of True
+                    object_name="rule",
+                    return_value=True
+                )
+            ],
+            log={
+                "action": "Blocked",
+                "internalIp": ""
+            }
+        ),
+    ]
+
+
+    
+class OutsideMockTest(Rule):
+    id = "outside_mock_test"
+    display_name = "Outside Mock Test"
+    default_description = "This rule provides an example of how to mock objects outside of the rule class in rule tests."
+    log_types = [LogType.AZURE_AUDIT]
+    default_severity = Severity.INFO
+    create_alert = False
+
+    def rule(self, event):
+        return outside() == "outside"
+    
+    tests = [
+        RuleTest(
+            name="Mock outside new",
+            expected_result=False,
+            mocks=[
+                RuleMock(
+                    # Mock the object OUTSIDE with a new value "inside"
+                    object_name="OUTSIDE",
+                    new="inside"
+                )
+            ],
+            log={
+                "action": "Blocked",
+                "internalIp": ""
+            }
+        ),
+        RuleTest(
+            name="Mock outside return_value",
+            expected_result=False,
+            mocks=[
+                RuleMock(
+                    # Mock the function outside() with a return value "inside"
+                    object_name="outside",
+                    return_value="inside"
+                )
+            ],
+            log={
+                "action": "Blocked",
+                "internalIp": ""
+            }
+        ),
+        RuleTest(
+            name="Mock outside side_effect",
+            expected_result=False,
+            mocks=[
+                RuleMock(
+                    # Mock the function outside() with a side effect that returns "inside"
+                    object_name="outside",
+                    side_effect=lambda: "inside"
+                )
+            ],
+            log={
+                "action": "Blocked",
+                "internalIp": ""
+            }
+        ),
+    ]

--- a/content/rules/example_mocks.py
+++ b/content/rules/example_mocks.py
@@ -22,6 +22,7 @@ class MockTestRule(Rule):
     create_alert = False
 
     INSIDE: list[str] = []
+
     def inside(self, event):
         return self.INSIDE
 

--- a/content/rules/example_mocks.py
+++ b/content/rules/example_mocks.py
@@ -21,10 +21,12 @@ class MockTestRule(Rule):
     default_severity = Severity.INFO
     create_alert = False
 
-    VARIABLE: list[str] = []
+    INSIDE: list[str] = []
+    def inside(self, event):
+        return self.INSIDE
 
     def rule(self, event):
-        return self.VARIABLE != []
+        return self.INSIDE != []
 
     tests = [
         RuleTest(
@@ -32,8 +34,8 @@ class MockTestRule(Rule):
             expected_result=True,
             mocks=[
                 RuleMock(
-                    # Mock the object VARIABLE with a new object ["test"]
-                    object_name="VARIABLE",
+                    # Mock the object INSIDE with a new object ["test"]
+                    object_name="INSIDE",
                     new=["test"],
                 )
             ],
@@ -44,9 +46,9 @@ class MockTestRule(Rule):
             expected_result=True,
             mocks=[
                 RuleMock(
-                    # Mock the method rule() with a side effect that checks if the action is "Blocked"
-                    object_name="rule",
-                    side_effect=lambda e: e.get("action") == "Blocked",
+                    # Mock the method inside() with a side effect that checks if the action is "Blocked"
+                    object_name="inside",
+                    side_effect=lambda e: bool(e.get("action") == "Blocked"),
                 )
             ],
             log={"action": "Blocked", "internalIp": ""},
@@ -56,8 +58,8 @@ class MockTestRule(Rule):
             expected_result=True,
             mocks=[
                 RuleMock(
-                    # Mock the method rule() with a return value of True
-                    object_name="rule",
+                    # Mock the method inside() with a return value of True
+                    object_name="inside",
                     return_value=True,
                 )
             ],


### PR DESCRIPTION
This is an example of how to use mocks in your tests.
The mocks are used to replace the actual object with a mock object.
The mock object can be a new object, a return value, or a side effect.
You can mock objects that are defined in the rule class or outside of the rule class.
http://www.ines-panker.com/2020/06/01/python-mock.html