### PR TITLE
Fix mock tests

### DIFF
--- a/content/rules/example_mocks.py
+++ b/content/rules/example_mocks.py
@@ -27,7 +27,7 @@ class MockTestRule(Rule):
         return self.INSIDE
 
     def rule(self, event):
-        return self.INSIDE != []
+        return self.inside(event) != []
 
     tests = [
         RuleTest(


### PR DESCRIPTION
Inside mock test rule was not calling `inside()` function to appropriately test all mock functionalyity.