### PR TITLE
Upload workflow option fix

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -25,4 +25,4 @@ jobs:
         run: poetry run pypanther test
       - name: pypanther upload
         run: |
-          poetry run pypanther upload --api-host ${{ env.API_HOST }} --api-token ${{ env.API_TOKEN }} --confirm
+          poetry run pypanther upload --api-host ${{ env.API_HOST }} --api-token ${{ env.API_TOKEN }} --skip-summary


### PR DESCRIPTION
Change the upload workflow to use the --skip-summary option since it's running automatically and should not include an approval step. Adding --skip-summary to avoid breaking the workflow because of a confirmation check in the upload.py script.